### PR TITLE
Fix: Ensure satellite timer is started on consecutive runs

### DIFF
--- a/src/RunDisplay.qml
+++ b/src/RunDisplay.qml
@@ -76,6 +76,7 @@ Item {
                     if (isRunning) {
                         rundata.reset()
                         var currentTime = new Date
+                        satellite.active = true
                         GpxLog.open(currentTime.toISOString())
                     } else {
                         GpxLog.close()

--- a/src/main.qml
+++ b/src/main.qml
@@ -168,7 +168,7 @@ Application {
 
     PositionSource {
         id: satellite
-        active: true
+        active: false
         updateInterval: 1000
         preferredPositioningMethods: PositionSource.SatellitePositioningMethods
         onPositionChanged: {


### PR DESCRIPTION
Current behaviour is `satellite` timer is active on app start, and is set to inactive after a run is finished. When starting a second run without restarting the app, the timer is not set to active again, so location is never updated for consecutive runs.

This PR fixes that by starting the app with the timer deactivated, and activating it on every run start.