### PR TITLE
Add waypoints; Change filename format and directory structure

### DIFF
--- a/src/GpxLog.cpp
+++ b/src/GpxLog.cpp
@@ -20,12 +20,24 @@
 #include <string_view>
 #include <string>
 #include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QIODevice>
+#include <QDateTime>
 #include "GpxLog.h"
 
 Q_INVOKABLE bool GpxLog::open(const QString& datetime) 
 {
+    const QString dirPath = "/home/ceres/runlogs";
+    if (!QDir(dirPath).exists()) {
+        if (!QDir().mkdir(dirPath)) {
+            qDebug() << "Failed to create directory";
+        }
+    }
+    std::string timestamp{QDateTime::fromString(datetime, Qt::ISODate).toLocalTime().toString("yyyy-MM-dd_HH-mm-ss").toStdString()};
     std::string now{datetime.toStdString()};
-    const std::string filepath{std::format("/home/ceres/runlog{}.gpx", now)};
+    filepath = std::format("/home/ceres/runlogs/runlog_{}.gpx", timestamp);
+    filepathwp = std::format("/home/ceres/runlogs/waypoints_{}.gpx", timestamp);
     static constexpr std::string_view header{R"(<?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.1" creator="AsteroidGPX" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">
   <metadata>
@@ -38,12 +50,17 @@ Q_INVOKABLE bool GpxLog::open(const QString& datetime)
     <trkseg>
 )"};
     out.open(filepath);
-    if (out.is_open()) {
-        out << header << now << trkopen;
-        return true;
+    if (!out.is_open()) {
+        qDebug() << "Writing file \"" << QString::fromStdString(filepath) << "\" FAILED";
+        return false;
     }
-    qDebug() << "Writing file \"" << QString::fromStdString(filepath) << "\" FAILED";
-    return false;
+    outwp.open(filepathwp);
+    if (!outwp.is_open()) {
+        qDebug() << "Writing file \"" << QString::fromStdString(filepathwp) << "\" FAILED";
+        return false;
+    }
+    out << header << now << trkopen;
+    return true;
 }
 
 Q_INVOKABLE bool GpxLog::logGPXsegment(const QString& datetime, double latitude, double longitude, double altitude, int satellites, int heartrate)
@@ -54,8 +71,7 @@ Q_INVOKABLE bool GpxLog::logGPXsegment(const QString& datetime, double latitude,
     }
     const std::string now{datetime.toStdString()};
 
-out 
-    << format(R"(      <trkpt lat="{:.5f}" lon="{:.5f}">
+out << format(R"(      <trkpt lat="{:.5f}" lon="{:.5f}">
         <ele>{:.1f}</ele>
         <time>{}</time>
         <sat>{}</sat>
@@ -75,7 +91,7 @@ Q_INVOKABLE bool GpxLog::logGPXwaypoint(const QString& datetime, double latitude
 {
     const std::string now{datetime.toStdString()};
 
-waypoints += format(R"(  <wpt lat="{:.5f}" lon="{:.5f}">
+outwp << format(R"(  <wpt lat="{:.5f}" lon="{:.5f}">
     <ele>{:.1f}</ele>
     <time>{}</time>
     <sat>{}</sat>
@@ -87,12 +103,39 @@ waypoints += format(R"(  <wpt lat="{:.5f}" lon="{:.5f}">
 
 Q_INVOKABLE bool GpxLog::close()
 {
-    if (out.is_open()) {
-        out << "    </trkseg>\n  </trk>\n" << waypoints << "</gpx>\n";
-        out.close();
-        waypoints = "";
-        return true;
-    } 
-    qDebug() << "ERROR: Closing file that is already closed";
-    return false;
+    if (!out.is_open() || !outwp.is_open()) {
+        qDebug() << "ERROR: Closing file that is already closed";
+        return false;
+    }
+
+    out << "    </trkseg>\n  </trk>\n</gpx>\n";
+    out.close();
+    outwp.close();
+
+    // inject waypoints to GPX runlog, delete waypoints file after
+    QFile ftrk(QString::fromStdString(filepath));
+    if (!ftrk.open(QFile::ReadOnly | QFile::Text)) {
+        qDebug() << "ERROR: Could not open track file";
+        return false;
+    }
+    QFile fwpt(QString::fromStdString(filepathwp));
+    if (!fwpt.open(QFile::ReadOnly | QFile::Text)) {
+        qDebug() << "ERROR: Could not open waypoint file";
+        return false;
+    }
+    QString strtrk = ftrk.readAll();
+    QString strwpt = fwpt.readAll();
+    ftrk.close();
+    fwpt.close();
+    strtrk.replace("  <trk>", strwpt + "  <trk>");
+    if(!ftrk.open(QIODevice::WriteOnly)) {
+        qDebug() << "ERROR: Could not open track file for writing";
+        return false;
+    } else {
+        ftrk.write(strtrk.toUtf8());
+        ftrk.close();
+    }
+    QFile::remove(QString::fromStdString(filepathwp));
+
+    return true;
 }

--- a/src/GpxLog.cpp
+++ b/src/GpxLog.cpp
@@ -71,11 +71,26 @@ out
     return true;
 }
 
+Q_INVOKABLE bool GpxLog::logGPXwaypoint(const QString& datetime, double latitude, double longitude, double altitude, int satellites)
+{
+    const std::string now{datetime.toStdString()};
+
+waypoints += format(R"(  <wpt lat="{:.5f}" lon="{:.5f}">
+    <ele>{:.1f}</ele>
+    <time>{}</time>
+    <sat>{}</sat>
+  </wpt>
+)", latitude, longitude, 
+    altitude, now, satellites);
+    return true;
+}
+
 Q_INVOKABLE bool GpxLog::close()
 {
     if (out.is_open()) {
-        out << "    </trkseg>\n  </trk>\n</gpx>\n";
+        out << "    </trkseg>\n  </trk>\n" << waypoints << "</gpx>\n";
         out.close();
+        waypoints = "";
         return true;
     } 
     qDebug() << "ERROR: Closing file that is already closed";

--- a/src/GpxLog.h
+++ b/src/GpxLog.h
@@ -38,6 +38,8 @@ private:
     GpxLog(const GpxLog&) = delete;
     GpxLog &operator=(const GpxLog&) = delete;
     std::ofstream out;
-    std::string waypoints;
+    std::ofstream outwp;
+    std::string filepath;
+    std::string filepathwp;
 };
 #endif // GPXLOG_H

--- a/src/GpxLog.h
+++ b/src/GpxLog.h
@@ -29,6 +29,7 @@ public:
         return &instance;
     }
     Q_INVOKABLE bool logGPXsegment(const QString& datetime, double latitude, double longitude, double altitude, int satellites, int heartrate);
+    Q_INVOKABLE bool logGPXwaypoint(const QString& datetime, double latitude, double longitude, double altitude, int satellites);
     Q_INVOKABLE bool open(const QString& datetime);
     Q_INVOKABLE bool close();
 private:
@@ -37,5 +38,6 @@ private:
     GpxLog(const GpxLog&) = delete;
     GpxLog &operator=(const GpxLog&) = delete;
     std::ofstream out;
+    std::string waypoints;
 };
 #endif // GPXLOG_H

--- a/src/RunDisplay.qml
+++ b/src/RunDisplay.qml
@@ -51,18 +51,25 @@ Item {
     MceBatteryLevel {
         id: batteryLevel
     }
+    Timer {
+        id: whiteflag
+        interval: 2000
+        repeat: false
+        running: false
+        onTriggered: waypoint.iconColor = "white"
+    }
     ColumnLayout {
         anchors.fill: parent
         spacing: 10
         Label {
             id: distance
-            Layout.topMargin: parent.height * 0.1
+            Layout.topMargin: parent.height * 0.15
             Layout.alignment: Qt.AlignCenter
-            Layout.preferredHeight: parent.height * 0.2
+            Layout.preferredHeight: parent.height * 0.17
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             font {
-                pixelSize: parent.height * 0.18
+                pixelSize: parent.height * 0.15
             }
             text: formatDistance(rundata.km)
         }
@@ -124,15 +131,35 @@ Item {
         }
         Label {
             id: time
-            Layout.bottomMargin: parent.height * 0.1
             Layout.alignment: Qt.AlignCenter
-            Layout.preferredHeight: parent.height * 0.2
+            Layout.preferredHeight: parent.height * 0.17
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             font {
-                pixelSize: parent.height * 0.18
+                pixelSize: parent.height * 0.15
             }
             text: formatMilliseconds(rundata.elapsed);
+        }
+        IconButton {
+            id: waypoint
+            iconName: "ios-flag"
+            Layout.alignment: Qt.AlignCenter
+            Layout.topMargin: parent.height * 0.03
+            Layout.preferredHeight: parent.height * 0.15
+            onClicked: {
+                if (isRunning) {
+                    waypoint.iconColor = "lightgreen"
+                    var currentTime = new Date
+                    GpxLog.logGPXwaypoint(
+                        currentTime.toISOString(),
+                        current_location.latitude,
+                        current_location.longitude,
+                        current_location.altitude,
+                        app.satsused
+                    );
+                    whiteflag.start()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds waypoint capabilities to `asteroid-skedaddle`. Tapping the ⚑ button will write a waypoint to a separate file. On ending a run, the waypoints file will be merged into the main track file, the waypoints file will be deleted.

Additionally, the datetime format for the filename is now `yyyy-MM-dd_HH-mm-SS` to avoid colons in the filename. This also uses the local timezone set on the watch now instead of UTC. Timestamps within the GPX file continue to be in UTC.

Last, logs are now stored in `/home/ceres/runlogs` instead of `/home/ceres` after making sure the new directory exists.