### PR TITLE
Fix: keep satellite position running at all times

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(${CMAKE_PROJECT_NAME} main.cpp resources.qrc Voice.cpp GpxLog.cpp)
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
-	AsteroidApp
+	Asteroid::AsteroidApp
         espeak)
 
 target_compile_features(${CMAKE_PROJECT_NAME} PUBLIC cxx_std_20)

--- a/src/RunDisplay.qml
+++ b/src/RunDisplay.qml
@@ -79,7 +79,6 @@ Item {
                         GpxLog.open(currentTime.toISOString())
                     } else {
                         GpxLog.close()
-                        satellite.active = false
                     }
                 }
             }


### PR DESCRIPTION
This allows successive runs (hit pause, then start again) to work by not shutting down satellite positioning under any circumstance.  This supercedes https://github.com/beroset/asteroid-skedaddle/pull/25 and makes the app simpler.